### PR TITLE
Add time period support for API URLs

### DIFF
--- a/src/Http/Controllers/DashboardController.php
+++ b/src/Http/Controllers/DashboardController.php
@@ -3,23 +3,23 @@
 namespace Robertogallea\PulseApi\Http\Controllers;
 
 use Robertogallea\PulseApi\Http\Resources\DashboardResource;
+use Illuminate\Http\Request;
 
-class DashboardController
-{
-    public function index()
-    {
-        return new DashboardResource(null);
+class PulseDashboardController {
+    public function index(Request $request) {
+        $period = $request->query('period', '');
+        return new DashboardResource(null, $period);
     }
 
-    public function show(string $type)
-    {
+    public function show(Request $request, string $type) {
+        $period = $request->query('period', '');
         if (array_key_exists($type, config('pulse-api.resources')->toArray())) {
-            return new (config('pulse-api.resources.'.$type))(null);
+            return new (config('pulse-api.resources.' . $type))(null, $period);
         }
 
         return response()->json([
             'data' => [
-                'message' => 'Metric type "'.$type.'" does not exist.',
+                'message' => 'Metric type "' . $type . '" does not exist.',
             ],
         ], 404);
     }

--- a/src/Http/Controllers/DashboardController.php
+++ b/src/Http/Controllers/DashboardController.php
@@ -5,22 +5,25 @@ namespace Robertogallea\PulseApi\Http\Controllers;
 use Illuminate\Http\Request;
 use Robertogallea\PulseApi\Http\Resources\DashboardResource;
 
-class DashboardController {
-    public function index(Request $request) {
+class DashboardController
+{
+    public function index(Request $request)
+    {
         $period = $request->query('period', '');
 
         return new DashboardResource(null, $period);
     }
 
-    public function show(Request $request, string $type) {
+    public function show(Request $request, string $type)
+    {
         $period = $request->query('period', '');
         if (array_key_exists($type, config('pulse-api.resources')->toArray())) {
-            return new (config('pulse-api.resources.' . $type))(null, $period);
+            return new (config('pulse-api.resources.'.$type))(null, $period);
         }
 
         return response()->json([
             'data' => [
-                'message' => 'Metric type "' . $type . '" does not exist.',
+                'message' => 'Metric type "'.$type.'" does not exist.',
             ],
         ], 404);
     }

--- a/src/Http/Controllers/DashboardController.php
+++ b/src/Http/Controllers/DashboardController.php
@@ -2,24 +2,28 @@
 
 namespace Robertogallea\PulseApi\Http\Controllers;
 
-use Robertogallea\PulseApi\Http\Resources\DashboardResource;
 use Illuminate\Http\Request;
+use Robertogallea\PulseApi\Http\Resources\DashboardResource;
 
-class PulseDashboardController {
-    public function index(Request $request) {
+class PulseDashboardController
+{
+    public function index(Request $request)
+    {
         $period = $request->query('period', '');
+
         return new DashboardResource(null, $period);
     }
 
-    public function show(Request $request, string $type) {
+    public function show(Request $request, string $type)
+    {
         $period = $request->query('period', '');
         if (array_key_exists($type, config('pulse-api.resources')->toArray())) {
-            return new (config('pulse-api.resources.' . $type))(null, $period);
+            return new (config('pulse-api.resources.'.$type))(null, $period);
         }
 
         return response()->json([
             'data' => [
-                'message' => 'Metric type "' . $type . '" does not exist.',
+                'message' => 'Metric type "'.$type.'" does not exist.',
             ],
         ], 404);
     }

--- a/src/Http/Controllers/DashboardController.php
+++ b/src/Http/Controllers/DashboardController.php
@@ -5,7 +5,7 @@ namespace Robertogallea\PulseApi\Http\Controllers;
 use Robertogallea\PulseApi\Http\Resources\DashboardResource;
 use Illuminate\Http\Request;
 
-class PulseDashboardController {
+class DashboardController {
     public function index(Request $request) {
         $period = $request->query('period', '');
         return new DashboardResource(null, $period);

--- a/src/Http/Resources/PulseResource.php
+++ b/src/Http/Resources/PulseResource.php
@@ -8,9 +8,13 @@ use Laravel\Pulse\Facades\Pulse;
 use Laravel\Pulse\Livewire\Concerns\HasPeriod;
 use Laravel\Pulse\Livewire\Concerns\RemembersQueries;
 
-class PulseResource extends JsonResource
-{
+class PulseResource extends JsonResource {
     use HasPeriod, RemembersQueries;
+
+    public function __construct($resource, $period = null) {
+        parent::__construct($resource);
+        $this->period = $period;
+    }
 
     /**
      * Retrieve values for the given type.
@@ -22,8 +26,7 @@ class PulseResource extends JsonResource
      *     value: string
      * }>
      */
-    protected function values(string $type, ?array $keys = null): Collection
-    {
+    protected function values(string $type, ?array $keys = null): Collection {
         return Pulse::values($type, $keys);
     }
 
@@ -34,8 +37,7 @@ class PulseResource extends JsonResource
      * @param  'count'|'min'|'max'|'sum'|'avg'  $aggregate
      * @return \Illuminate\Support\Collection<string, \Illuminate\Support\Collection<string, \Illuminate\Support\Collection<string, int|null>>>
      */
-    protected function graph(array $types, string $aggregate): Collection
-    {
+    protected function graph(array $types, string $aggregate): Collection {
         return Pulse::graph($types, $aggregate, $this->periodAsInterval());
     }
 

--- a/src/Http/Resources/PulseResource.php
+++ b/src/Http/Resources/PulseResource.php
@@ -8,10 +8,12 @@ use Laravel\Pulse\Facades\Pulse;
 use Laravel\Pulse\Livewire\Concerns\HasPeriod;
 use Laravel\Pulse\Livewire\Concerns\RemembersQueries;
 
-class PulseResource extends JsonResource {
+class PulseResource extends JsonResource
+{
     use HasPeriod, RemembersQueries;
 
-    public function __construct($resource, $period = null) {
+    public function __construct($resource, $period = null)
+    {
         parent::__construct($resource);
         $this->period = $period;
     }
@@ -26,7 +28,8 @@ class PulseResource extends JsonResource {
      *     value: string
      * }>
      */
-    protected function values(string $type, ?array $keys = null): Collection {
+    protected function values(string $type, ?array $keys = null): Collection
+    {
         return Pulse::values($type, $keys);
     }
 
@@ -37,7 +40,8 @@ class PulseResource extends JsonResource {
      * @param  'count'|'min'|'max'|'sum'|'avg'  $aggregate
      * @return \Illuminate\Support\Collection<string, \Illuminate\Support\Collection<string, \Illuminate\Support\Collection<string, int|null>>>
      */
-    protected function graph(array $types, string $aggregate): Collection {
+    protected function graph(array $types, string $aggregate): Collection
+    {
         return Pulse::graph($types, $aggregate, $this->periodAsInterval());
     }
 


### PR DESCRIPTION
### Addresses #2 
Simply takes the period query from the API URL and passes it on to the PulseResource such that the HasPeriod trait's period property is filled.

Example for one of the DashboardController Methods
```php
public function index(Request $request)
{
    $period = $request->query('period', '');

    return new DashboardResource(null, $period);
}
```

Applying it to PulseResource
```php
class PulseResource extends JsonResource
{
    use HasPeriod, RemembersQueries;

    public function __construct($resource, $period = null)
    {
        parent::__construct($resource);
        $this->period = $period;
    }
```

Example URL:
/api/pulse?period=6_hours

### To add: 

By default, pulse only has the four time periods as defined in the HasPeriod trait:

```php
return match ($this->period) {
    '6_hours' => '6 hours',
    '24_hours' => '24 hours',
    '7_days' => '7 days',
    default => 'hour',
};
```

Ideally, any valid input to 
```php
CarbonInterval::hours(match ($this->period)
```
should work since this is an API and the UI isnt limited to whatever is in the default pulse package. Could just make a custom copy of the HasPeriod trait. 

