### PR TITLE
Fix missing parameter in Dashboard Resource

### DIFF
--- a/src/Http/Resources/DashboardResource.php
+++ b/src/Http/Resources/DashboardResource.php
@@ -4,14 +4,12 @@ namespace Robertogallea\PulseApi\Http\Resources;
 
 use Illuminate\Http\Request;
 
-class DashboardResource extends PulseResource
-{
-    public function toArray(Request $request): array
-    {
+class DashboardResource extends PulseResource {
+    public function toArray(Request $request): array {
         $resources = config('pulse-api.resources');
 
         $result = $resources->mapWithKeys(function (string $resource, string $key) use ($request) {
-            return (new $resource(null))->toArray($request);
+            return (new $resource(null, $this->period))->toArray($request);
         });
 
         return $result->toArray();

--- a/src/Http/Resources/DashboardResource.php
+++ b/src/Http/Resources/DashboardResource.php
@@ -4,8 +4,10 @@ namespace Robertogallea\PulseApi\Http\Resources;
 
 use Illuminate\Http\Request;
 
-class DashboardResource extends PulseResource {
-    public function toArray(Request $request): array {
+class DashboardResource extends PulseResource
+{
+    public function toArray(Request $request): array
+    {
         $resources = config('pulse-api.resources');
 
         $result = $resources->mapWithKeys(function (string $resource, string $key) use ($request) {


### PR DESCRIPTION
The Dashboard Resource needs to use its period property when instantiating all the other Pulse Resources. 