### PR TITLE
Fix bug where the configuration file can not be serialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ integrate the default ones by editing the `resources` configuration section:
 'resources' =>
     \Robertogallea\PulseApi\Services\PulseAPI::getDefaultResources()->merge([
         // Add your custom resources
-    ]),
+    ])->toArray(),
 ```
 
 ### Including recorders configuration in json response

--- a/config/pulse-api.php
+++ b/config/pulse-api.php
@@ -67,6 +67,6 @@ return [
 
     'resources' => \Robertogallea\PulseApi\Services\PulseAPI::getDefaultResources()->merge([
         // Add your custom resources
-    ]),
+    ])->toArray(),
 
 ];

--- a/src/Http/Controllers/DashboardController.php
+++ b/src/Http/Controllers/DashboardController.php
@@ -17,7 +17,7 @@ class DashboardController
     public function show(Request $request, string $type)
     {
         $period = $request->query('period', '');
-        if (array_key_exists($type, config('pulse-api.resources')->toArray())) {
+        if (array_key_exists($type, config('pulse-api.resources'))) {
             return new (config('pulse-api.resources.'.$type))(null, $period);
         }
 

--- a/src/Http/Resources/DashboardResource.php
+++ b/src/Http/Resources/DashboardResource.php
@@ -10,7 +10,7 @@ class DashboardResource extends PulseResource
     {
         $resources = config('pulse-api.resources');
 
-        $result = $resources->mapWithKeys(function (string $resource, string $key) use ($request) {
+        $result = collect($resources)->mapWithKeys(function (string $resource, string $key) use ($request) {
             return (new $resource(null, $this->period))->toArray($request);
         });
 

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -70,6 +70,6 @@ function createFakeResourceClass()
 
     Config::set(
         'pulse-api.resources',
-        collect(['fake-resource' => FakeResource::class])
+        ['fake-resource' => FakeResource::class]
     );
 }


### PR DESCRIPTION
The "resources" key in the pulse-api.php config file is a Collection instance.
On running config:cache an error is thrown: "Your configuration files are not serializable."

This PR changes the "resources" value to an array.